### PR TITLE
Add age verification to simulation form

### DIFF
--- a/app.js
+++ b/app.js
@@ -15,6 +15,7 @@ const toggleRescate = document.getElementById('toggleRescate');
 const mesRescateInput = document.getElementById('mesRescate');
 const mesRescateLabel = document.getElementById('mesRescateLabel');
 const themeToggleBtn = document.getElementById('themeToggle');
+const errorFechaNacimiento = document.getElementById('errorFechaNacimiento');
 
 // ===========================
 // Tema (oscuro/claro) con persistencia
@@ -202,6 +203,18 @@ function renderChart(rows, rescate) {
 let lastRows = null;
 let lastRescate = null;
 
+function esMayorDeEdad(fechaNacimiento) {
+  const nacimiento = new Date(fechaNacimiento);
+  const hoy = new Date();
+  if (Number.isNaN(nacimiento.getTime())) return false;
+  let edad = hoy.getFullYear() - nacimiento.getFullYear();
+  const mes = hoy.getMonth() - nacimiento.getMonth();
+  if (mes < 0 || (mes === 0 && hoy.getDate() < nacimiento.getDate())) {
+    edad--;
+  }
+  return edad >= 18;
+}
+
 // Ejecuta toda la simulación y render con la tasa indicada
 async function runSimulacion({ nombre, fechaNacimiento, aporteMensual, motivo, plazoAnios, metodoPago, tasaAnual }) {
   const rows = simular(aporteMensual, plazoAnios, tasaAnual);
@@ -270,6 +283,14 @@ form.addEventListener('submit', async (e) => {
   if (!nombre || !fechaNacimiento || !aporteMensual || !plazoAnios) {
     alert('Completá todos los campos obligatorios.');
     return;
+  }
+
+  if (!esMayorDeEdad(fechaNacimiento)) {
+    alert('Debés ser mayor de 18 años.');
+    errorFechaNacimiento.hidden = false;
+    return;
+  } else {
+    errorFechaNacimiento.hidden = true;
   }
 
   const fondo = seleccionarFondoPorPlazo(plazoAnios);

--- a/index.html
+++ b/index.html
@@ -54,6 +54,7 @@
         </label>
         <label>Fecha de nacimiento
           <input type="date" id="fechaNacimiento" required />
+          <small id="errorFechaNacimiento" class="error" hidden>Debés ser mayor de 18 años.</small>
         </label>
       </div>
 

--- a/styles.css
+++ b/styles.css
@@ -93,6 +93,7 @@ input:focus,select:focus{
   box-shadow: 0 0 0 3px color-mix(in oklab, var(--accent-2) 25%, transparent);
 }
 small{color:var(--muted)}
+.error{color:#ef4444}
 
 .actions{display:flex;gap:10px;margin-top:8px}
 button{


### PR DESCRIPTION
## Summary
- add helper to check if a user is at least 18 years old
- prevent simulation if the user is underage and display inline error
- style birthdate error message

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0cbbff6ec832fbdd581d9ca15b66b