### PR TITLE
Integrate UVA index with UVA-adjusted simulations

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -123,6 +123,7 @@ thead th{
   position:sticky;top:0;
   background: var(--card);
 }
+tr.estimado td{font-style:italic;opacity:.8}
 
 .chart-wrap{
   margin:14px 0;border:1px solid var(--border);border-radius:12px;overflow:hidden;


### PR DESCRIPTION
## Summary
- fetch UVA series from BCRA and compute monthly factors
- adjust simulated contributions by UVA and extrapolate missing data
- flag and style estimated months and add disclaimer to results

## Testing
- `node --check app.js`
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68b0d09065b4832fa0e895999545fd6c